### PR TITLE
feat: simplified port configs

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,7 +1,7 @@
 import switch
 
-sw = switch.NetgearSwitch(ip = "192.168.0.239", cookieName="SID", password="password", mode=2)
+sw = switch.NetgearSwitch(ip = "192.168.0.239", cookieName="SID", password="Skynode0", mode=2)
 # Disable
-# sw.setPortState("port3","2","2")
+sw.setPortState(3, turnOn=False)
 # Enable
-sw.setPortState("port3","1","2")
+sw.setPortState(3)

--- a/switch.py
+++ b/switch.py
@@ -209,7 +209,14 @@ class NetgearSwitch():
     def getDevicePropByName(self, name):
         return(self.deviceInfo[name])
 
-    def setPortState(self, portName, speed, flow):
+    def setPortState(self, port, speed=1, flow='2', turnOn=True):
+        '''
+        Configure individual ports\n
+        Pass only `port` to reset to default (ON, Auto)\n
+        Pass with `turnOn=False` to disable port\n
+        `port` is either int (1,2..) or name (port1, port2...)
+        See function for more options
+        '''
         speedTable = {
             "Auto": 1,
             "Disable": 2,
@@ -222,8 +229,15 @@ class NetgearSwitch():
             pI = int(speed)
         except ValueError:
             speed = speedTable[speed]
-        
-        
+
+        try:
+            portName = f"port{int(port)}"
+        except ValueError:
+            portName = port
+
+        if not turnOn:
+            speed = 2
+
         if(self.__mode__ == 2):
             headers = {'User-Agent': 'Mozilla/5.0','Content-Type':'application/x-www-form-urlencoded'}
             payload = {'DESCRIPTION': portName, 'SPEED':speed,'FLOW_CONTROL':flow,portName:'checked','hash':self.__hash__}


### PR DESCRIPTION

   * setPortState accepts both integers (1,2..) and full port names (port1, port2...)
   * setPortState has turnOn flag, to simply disable port

Simplified use case is as follows:

```
# Disable port no3
sw.setPortState(3, turnOn=False)
# Enable port no3
sw.setPortState(3)
```